### PR TITLE
Revamp ALL Authkeys to come from ONE org (And added detection script)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,15 @@ Polyverse Katacoda scenarios
 
 This website also powers [Polyverse Learning](https://polyverse.io/learn),
 through [GitHub Pages](https://pages.github.com).
+
+## IMPORTANT NOTE ABOUT AUTHKEYS
+
+We had keys from various orgs being used for Katacoda demos. They now
+come from this single org: https://polyverse.com/account/org/2a041da04bf15b8064b708594df593ee/authkeys
+
+If you don't have access to it, please request access. Begin deprecating other orgs
+that do the same thing.
+
+This will allow for visibility, but also allows the upcoming
+Detect keys to be consolidated in one place for all demos.
+

--- a/detect-beta/install-polyverse.md
+++ b/detect-beta/install-polyverse.md
@@ -2,7 +2,7 @@ Now we can take a look at the dashboard when a Polyverse-protected version of Ng
 
 Let’s begin by installing Polyverse...
 
-`curl https://sh.polyverse.io | sh -s install czcw7pjshny8lzzog8bgiizfr webdemo@polyverse.com`{{execute}}
+`curl https://sh.polyverse.io | sh -s install JNQ0WGbinpS7iOKOpsaos4cpm webdemo@polyverse.com`{{execute}}
 
 Now that Polymorphic Linux is installed in the container we can add a polymorphic version of Nginx by running the command below.
 

--- a/detect-beta/intro.sh
+++ b/detect-beta/intro.sh
@@ -1,2 +1,7 @@
 #!/bin/bash
+
+echo "Starting dashboard..."
 docker run -p 8080:8080 -d --rm polyverse/detect-demo-dashboard
+
+echo "Installing Polytect..."
+curl -L https://github.com/polyverse/polytect/releases/latest/download/install.sh | sudo sh -s "xU9XiObcoKnSNpRhpuwt5Lrem" "katacoda_detect_scenario"

--- a/detect/install-polyverse.md
+++ b/detect/install-polyverse.md
@@ -1,6 +1,6 @@
 Now let's install Polymorphic Linux.
 
-`curl https://sh.polyverse.io | sh -s install czcw7pjshny8lzzog8bgiizfr webdemo@polyverse.com`{{execute}}
+`curl https://sh.polyverse.io | sh -s install JNQ0WGbinpS7iOKOpsaos4cpm webdemo@polyverse.com`{{execute}}
 
 We just add our repositories to sources.list, allowing you to download Polymorphic versions of standard Linux packages and libraries, including Nginx.
 

--- a/polymorphic-linux-install-alpine-container/subscribe.md
+++ b/polymorphic-linux-install-alpine-container/subscribe.md
@@ -1,8 +1,8 @@
 Polymorphic Linux is distributed as drop-in replacement packages for all of the existing packages on your
-host. To use, simply point your package repository to the Polyverse repositories instead of a community run “mirror”. From then on, Polymorphic Linux operates identically to standard Linux. 
+host. To use, simply point your package repository to the Polyverse repositories instead of a community run “mirror”. From then on, Polymorphic Linux operates identically to standard Linux.
 
 
 We provide a simple script to subscribe to the mirrors, this command can be found on the
 [free trial page](https://polyverse.io/polymorphic-linux-installation-guide/)of our website or simply click on the command below:
 
-`curl https://sh.polyverse.io | sh -s install IPHJz5iR9hz9pxSrpxrZWnEu9 webdemo@polyverse.io`{{execute}}
+`curl https://sh.polyverse.io | sh -s install i3BIaA6dfTmsK4bFNWIgHwJr6 webdemo@polyverse.io`{{execute}}

--- a/polymorphic-linux-install-rhel-container-beta/subscribe.md
+++ b/polymorphic-linux-install-rhel-container-beta/subscribe.md
@@ -4,4 +4,4 @@ Polymorphic Linux is distributed as drop-in replacement packages for all of the 
 We provide a simple script to subscribe to the mirrors, found on the
 [free trial page](https://polyverse.io/polymorphic-linux-installation-guide/).
 
-`curl https://sh.polyverse.io | sh -s install y5ynNlxjMYNuuukIJETwPUcwr rhelwebdemo@polyverse.io`{{execute}}
+`curl https://sh.polyverse.io | sh -s install Lux46NjvHtxe6MqXqwECpolaf rhelwebdemo@polyverse.io`{{execute}}

--- a/polymorphic-linux-install-rhel-container/subscribe.md
+++ b/polymorphic-linux-install-rhel-container/subscribe.md
@@ -4,4 +4,4 @@ Polymorphic Linux is distributed as drop-in replacement packages for all of the 
 We provide a simple script to subscribe to the mirrors, found on the
 [free trial page](https://polyverse.io/polymorphic-linux-installation-guide/).
 
-`curl https://sh.polyverse.io | sh -s install y5ynNlxjMYNuuukIJETwPUcwr rhelwebdemo@polyverse.io`{{execute}}
+`curl https://sh.polyverse.io | sh -s install Lux46NjvHtxe6MqXqwECpolaf rhelwebdemo@polyverse.io`{{execute}}

--- a/polymorphic-linux-install-rhel-host/subscribe.md
+++ b/polymorphic-linux-install-rhel-host/subscribe.md
@@ -4,4 +4,4 @@ Polymorphic Linux is distributed as drop-in replacement packages for all of the 
 We provide a simple script to subscribe to the mirrors, found on the
 [free trial page](https://polyverse.io/polymorphic-linux-installation-guide/).
 
-`curl https://sh.polyverse.io | sh -s install hxEcy3ESX5k31MFwxiGH5thyR rhelwebdemo@polyverse.io`{{execute}}
+`curl https://sh.polyverse.io | sh -s install mHwQCqmmoOQpVk5IQ5C4hpttx rhelwebdemo@polyverse.io`{{execute}}

--- a/polymorphic-linux-install-ubuntu-host/subscribe.md
+++ b/polymorphic-linux-install-ubuntu-host/subscribe.md
@@ -4,4 +4,4 @@ host, by pulling them from a Polyverse "mirror".
 We provide a simple script to subscribe to the mirrors, found on the
 [free trial page](https://polyverse.io/polymorphic-linux-installation-guide/).
 
-`curl https://sh.polyverse.io | sh -s install sQGdlrCMiA9EsLRhm227fAOzS webdemo@polyverse.io`{{execute}}
+`curl https://sh.polyverse.io | sh -s install Cok5Cd9uC3hV5mTC04opmn5Jo webdemo@polyverse.io`{{execute}}


### PR DESCRIPTION
# Major Change 1:
We had keys from various orgs being used for Katacoda demos. They now
come from this single org: https://polyverse.com/account/org/2a041da04bf15b8064b708594df593ee/authkeys

If you don't have access to it, please request access. Begin deprecating other orgs
that do the same thing.

This will allow for visibility, but also allows the upcoming
Detect keys to be consolidated in one place for all demos.

# Major Change 2:
In the detect-beta, added a command to pre-install polytect before proceeding. I suspect this may not work, but it's a start. Once this is merged in, I'll iterate in the beta scenario directly on master and proceed.